### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   quality:
     name: Run project test set
+    permissions:
+      contents: read
     uses: ./.github/workflows/python-tests.yml
     with:
       target_workflow: ./.github/workflows/python-tests.yml


### PR DESCRIPTION
Potential fix for [https://github.com/qaldak/unbound-statistics-publisher/security/code-scanning/1](https://github.com/qaldak/unbound-statistics-publisher/security/code-scanning/1)

To fix the issue, add a `permissions` block to the `quality` job in the workflow file. This block should specify the least privileges required for the job. Since the `quality` job runs tests and does not appear to require write access, the permissions can be set to `contents: read`. This ensures the job has only the necessary access to the repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
